### PR TITLE
fix: CI workflow and lefthook configuration

### DIFF
--- a/.changeset/lazy-knives-sort.md
+++ b/.changeset/lazy-knives-sort.md
@@ -6,4 +6,5 @@ Fix CI workflow and lefthook configuration
 
 - Replace nlx with pnpm exec for consistent local package execution
 - Skip lefthook installation in CI environment to prevent hook conflicts
+- Update prepare script to use Node.js for Windows compatibility
 - Ensure changesets can commit without git hook interference

--- a/.changeset/lazy-knives-sort.md
+++ b/.changeset/lazy-knives-sort.md
@@ -1,0 +1,9 @@
+---
+"@mfyuu/utils": patch
+---
+
+Fix CI workflow and lefthook configuration
+
+- Replace nlx with pnpm exec for consistent local package execution
+- Skip lefthook installation in CI environment to prevent hook conflicts
+- Ensure changesets can commit without git hook interference

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+        env:
+          CI: true # for Disable lefthook in CI
 
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,10 +2,10 @@ pre-commit:
   commands:
     check:
       glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-      run: nlx biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+      run: pnpm exec biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
       stage_fixed: true
 pre-push:
   commands:
     check:
       glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-      run: nlx biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
+      run: pnpm exec biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 	],
 	"scripts": {
 		"preinstall": "npx only-allow pnpm",
-		"prepare": "lefthook install",
+		"prepare": "if [ \"$CI\" != \"true\" ]; then lefthook install; fi",
 		"build": "unbuild",
 		"dev": "unbuild --stub",
 		"format": "biome format --write .",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 	],
 	"scripts": {
 		"preinstall": "npx only-allow pnpm",
-		"prepare": "if [ \"$CI\" != \"true\" ]; then lefthook install; fi",
+		"prepare": "node -e \"if(process.env.CI !== 'true') { require('child_process').execSync('lefthook install', {stdio: 'inherit'}) }\"",
 		"build": "unbuild",
 		"dev": "unbuild --stub",
 		"format": "biome format --write .",


### PR DESCRIPTION
## Issue

N/A - CI/CD workflow fix and maintenance update

## Changes

- Replace nlx with pnpm exec in lefthook for consistent local package execution
- Add CI detection in prepare script to skip lefthook installation in CI environment
- Set CI environment variable in release workflow to prevent git hook conflicts

## Verification

- [x] Lefthook commands work correctly with pnpm exec
- [x] CI workflow skips lefthook installation properly
- [x] Changeset file created for version management
- [x] No breaking changes introduced

## Additional Notes

This PR fixes the CI workflow failure that occurred during automated release. The changeset will trigger a patch version bump (0.1.1 → 0.1.2) upon merge.