### PR TITLE
chore: disable renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,5 @@
 			"groupName": "major updates (manual review)"
 		}
 	],
-	"dependencyDashboard": true
+	"dependencyDashboard": false
 }


### PR DESCRIPTION
## Issue

N/A - Renovate configuration update

## Changes

- Disable dependency dashboard feature in renovate.json
- Set dependencyDashboard to false

## Verification

- [x] Renovate configuration validates without errors
- [x] No breaking changes introduced

## Additional Notes

This PR disables the dependency dashboard feature as it's not needed for this project. The dashboard creates unnecessary issue noise without providing significant value for a small project.